### PR TITLE
Fixed the wrong env variable being used

### DIFF
--- a/src/components/AppData/useUISettings.js
+++ b/src/components/AppData/useUISettings.js
@@ -235,7 +235,7 @@ export const useShowWhiteboard = () => {
     FEATURE_LIST.WHITEBOARD
   );
   const whiteboardRolesList =
-    process.env.REACT_APP_SHOW_AUDIO_SHARE_BUTTON_PERMISSION_ROLES;
+    process.env.REACT_APP_WHITEBOARD_BUTTON_PERMISSION_ROLES;
   const localPeerRoleName = useHMSStore(selectLocalPeerRoleName);
   // TODO handle array not present error
   const isRoleAllowedToShareWhiteBoard =


### PR DESCRIPTION
On removing the audio player we found > the wrong variable is being used in whiteboard > useUISettings.js 237 line
instead of REACT_APP_WHITEBOARD_BUTTON_PERMISSION_ROLES > >>> REACT_APP_SHOW_AUDIO_SHARE_BUTTON_PERMISSION_ROLES this is being used