### PR TITLE
Fixes HLS player on m-web not fitting the screen.

### DIFF
--- a/src/components/HMSVideo/HMSVideo.jsx
+++ b/src/components/HMSVideo/HMSVideo.jsx
@@ -5,7 +5,12 @@ export const HMSVideo = forwardRef(({ children }, videoRef) => {
   return (
     <Flex data-testid="hms-video" css={{ size: "100%" }} direction="column">
       <video
-        style={{ flex: "1 1 0", margin: "0 auto", minHeight: "0" }}
+        style={{
+          flex: "1 1 0",
+          margin: "0 auto",
+          minHeight: "0",
+          maxWidth: "100%",
+        }}
         ref={videoRef}
         playsInline
       />

--- a/src/plugins/whiteboard/useMultiplayerState.js
+++ b/src/plugins/whiteboard/useMultiplayerState.js
@@ -18,7 +18,6 @@ const useWhiteboardState = () => {
   return { shouldRequestState, amIWhiteboardOwner };
 };
 
-
 /**
  * Ref: https://github.com/tldraw/tldraw/blob/main/apps/www/hooks/useMultiplayerState.ts
  */
@@ -94,12 +93,8 @@ export function useMultiplayerState(roomId) {
       if (app) {
         if (!amIWhiteboardOwner) {
           // Currently only the owner can change the pan and zoom of the bord
-          app.setCamera(
-            camera.point,
-            camera.zoom,
-            "Remote change"
-          );
-          if(isHeadless) {
+          app.setCamera(camera.point, camera.zoom, "Remote change");
+          if (isHeadless) {
             app.zoomToFit();
           }
         }
@@ -222,7 +217,7 @@ export function useMultiplayerState(roomId) {
   );
 
   const updateCamera = useCallback(camera => {
-    if(!camera) {
+    if (!camera) {
       return;
     }
     camera.point && setPoint(camera.point);


### PR DESCRIPTION
Fixes HLS player on m-web not fitting the screen. The player was zoomed on to one peer even if there are multiple peers in the room. Now, it fits the width.

<img width="901" alt="Screenshot 2023-10-27 at 2 51 57 PM" src="https://github.com/100mslive/-alpha-edtech-template/assets/53579386/62e3fd7c-86ba-4685-a65a-4c597351912e">
